### PR TITLE
Update cloudbuild_auto_scoreboard.yaml

### DIFF
--- a/cloudbuild_auto_scoreboard.yaml
+++ b/cloudbuild_auto_scoreboard.yaml
@@ -4,7 +4,7 @@
 
 timeout: 9001s #2.5 hour time-out
 options:
-  machineType: 'N1_HIGHCPU_8' #could be 32 as well 'N1_HIGHCPU_32'
+  machineType: 'N1_HIGHCPU_32' #could be 32 as well 'N1_HIGHCPU_32'
 # Decrypt the file containing the key
 steps:
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
update the machine type for faster (and cheaper) regression